### PR TITLE
fix requirements and add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tags
 *.pyc
 log/
+dmbrl.egg-info/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy==1.14.0
 scipy==0.19.0
 tensorflow-gpu>=1.9.0
 tqdm==4.19.4
+pytest>=4.6.3

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+from setuptools import find_packages
+
+setup(
+    name='dmbrl',
+    version='0.1.0dev',
+    packages=find_packages(),
+    license='MIT License',
+    long_description=open('README.md').read(),
+)


### PR DESCRIPTION
Addresses #1  and makes it so that you can do `pip install -e .` to install `dmbrl`.