### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ future==0.16.0
 gpflow==1.1.0
 gym==0.9.4
 mujoco-py==0.5.7
-numpy==1.14.0
+numpy==1.16.0
 scipy==0.19.0
-tensorflow-gpu>=1.9.0
+tensorflow-gpu==1.14.0
+tensorflow==1.14.0
 tqdm==4.19.4


### PR DESCRIPTION
- `>=1.9.0` was causing a 2.x version to install which broke the code, so changed to explicitly require ==1.14.0
- Only works with tensorflow==1.14.0 and numpy==1.16.0